### PR TITLE
Improve test output

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@ const int chipSelect = 5;   // SD card CS pin
 
 volatile int endstopCounter = 0;
 unsigned long lastCycleEnd = 0; // When (in millis) did the last test cycle end
-unsigned int lineNumber = 1;    // Initialize line number
+unsigned int testCount = 1;     // Initialize line number
 boolean detectedSolenoidOn = 0;
 boolean detectedSolenoidOff = 0;
 unsigned long startTime;
@@ -40,7 +40,7 @@ void logResult(String result)
   File dataFile = SD.open("/text.txt", FILE_APPEND);
   if (dataFile)
   {
-    dataFile.print("Test " + lineNumber); // Print the line number
+    dataFile.print("Test " + String(testCount)); // Print the line number
     dataFile.print(": ");
     String colorCode;
     if (result.equals("PASS"))
@@ -51,14 +51,14 @@ void logResult(String result)
     dataFile.close();
 
     // Log to serial port
-    Serial.print("Test " + lineNumber); // Print the line number to serial monitor
+    Serial.print("Test " + String(testCount)); // Print the line number to serial monitor
     Serial.print(": ");
     if (result.equals("PASS"))
       Serial.print("\x1B[92m"); // Green
     else
       Serial.print("\x1B[91m");         // Red
     Serial.println(result + "\x1B[0m"); // Reset to default color
-    lineNumber++;                       // Increment the line number for next entry
+    testCount++;                        // Increment the line number for next entry
   }
   else
   {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,11 +6,19 @@ const int endstopPin = 34;  // Pin connected to endstop (must be interrupt-capab
 const int chipSelect = 5;   // SD card CS pin
 
 volatile int endstopCounter = 0;
-unsigned long lastTrigger = 0;
-unsigned int lineNumber = 1; // Initialize line number
+unsigned long lastCycleEnd = 0; // When (in millis) did the last test cycle end
+unsigned int lineNumber = 1;    // Initialize line number
+
+const unsigned long solenoidFrequency = 30000;  // pwm frequency for solenoid (Hz)
+const unsigned long solenoidPull = 255;         // pwm value for solenoid on (initial pull, max 255)
+const unsigned long solenoidHold = 100;         // pwm value for solenoid hold (holding while on, max 255)
+const unsigned long solenoidPullDuration = 100; // duration solenoid operates at pull setting
 
 const unsigned long maxOnDuration = 2000; // Maximum duration solenoid can stay on in milliseconds
 const unsigned long maxInterval = 3000;   // Maximum interval between cycles in milliseconds
+const unsigned long minInterval = 500;    // Minimum interval between cycles in milliseconds
+
+unsigned long timeBetweenTests = random(minInterval, maxInterval); // Generate a random interval
 
 void endstopISR()
 {
@@ -24,12 +32,23 @@ void logResult(String result)
   {
     dataFile.print(lineNumber); // Print the line number
     dataFile.print(": ");
-    dataFile.println(result);
+    String colorCode;
+    if (result.equals("PASS"))
+      colorCode = "\x1B[92m"; // Green
+    else
+      colorCode = "\x1B[91m";                         // Red
+    dataFile.println(colorCode + result + "\x1B[0m"); // Reset to default color
     dataFile.close();
+
+    // Log to serial port
     Serial.print(lineNumber); // Print the line number to serial monitor
     Serial.print(": ");
-    Serial.println(result);
-    lineNumber++; // Increment the line number for next entry
+    if (result.equals("PASS"))
+      Serial.print("\x1B[92m"); // Green
+    else
+      Serial.print("\x1B[91m");         // Red
+    Serial.println(result + "\x1B[0m"); // Reset to default color
+    lineNumber++;                       // Increment the line number for next entry
   }
   else
   {
@@ -39,7 +58,8 @@ void logResult(String result)
 
 void setup()
 {
-  Serial.begin(9600);
+  Serial.begin(115200);
+  analogWriteFrequency(solenoidFrequency);
   pinMode(solenoidPin, OUTPUT);
   pinMode(endstopPin, INPUT_PULLUP);
   attachInterrupt(digitalPinToInterrupt(endstopPin), endstopISR, FALLING); // Attach interrupt
@@ -51,36 +71,61 @@ void setup()
   }
   Serial.println("Card initialized.");
   randomSeed(analogRead(0)); // Seed the random generator with a noise reading
+
+  Serial.println("Solenoid initialization test. Solenoid On for 2 second");
+  analogWrite(solenoidPin, solenoidPull);
+  delay(2000);
+  Serial.println("Solenoid initialization test. Solenoid Off for 2 second");
+  analogWrite(solenoidPin, 0);
+  delay(2000);
+  Serial.println("Solenoid initialization test. Solenoid On for 1 second");
+  analogWrite(solenoidPin, solenoidPull);
+  delay(1000);
+  Serial.println("Solenoid initialization test. Solenoid Off for 1 second");
+  analogWrite(solenoidPin, 0);
+  delay(1000);
 }
 
-void loop() {
+void loop()
+{
   unsigned long currentMillis = millis();
-  unsigned long randomInterval = random(maxInterval); // Generate a random interval
 
-  if (currentMillis - lastTrigger >= randomInterval) {
-    lastTrigger = currentMillis;
-    endstopCounter = 0;  // Reset the endstop counter
+  if (currentMillis - lastCycleEnd >= timeBetweenTests)
+  {
 
     unsigned long onDuration = random(maxOnDuration); // Generate a random on duration
-    Serial.println("Triggering solenoid ON for " + String(onDuration) + " milliseconds");
-    digitalWrite(solenoidPin, HIGH);
+
+    Serial.println("Solenoid ON (" + String(onDuration) + " milliseconds)");
+    analogWrite(solenoidPin, solenoidPull);
+    delay(solenoidPullDuration);
+    analogWrite(solenoidPin, solenoidHold);
     delay(onDuration);
-    digitalWrite(solenoidPin, LOW);
+    analogWrite(solenoidPin, 0);
+
     Serial.println("Solenoid OFF");
 
     unsigned long startTime = millis();
-    while (millis() - startTime < 500) { // 500 ms timeout for detecting endstop
-      if (endstopCounter >= 2) { // Check if both pulses are detected
+    Serial.println(String(endstopCounter));
+    while (millis() - startTime < 500)
+    { // 500 ms timeout for detecting endstop
+      if (endstopCounter >= 2)
+      { // Check if both pulses are detected
         break;
       }
     }
 
-    if (endstopCounter >= 2) {
-      logResult("Success");
-    } else {
-      logResult("Failed");
+    if (endstopCounter >= 2)
+    {
+      logResult("PASS");
+    }
+    else
+    {
+      logResult("FAIL");
     }
 
-    Serial.println("Cycle completed. Waiting for next trigger after " + String(millis() - currentMillis) + " milliseconds.");
+    endstopCounter = 0;                                  // Reset the endstop counter
+    timeBetweenTests = random(minInterval, maxInterval); // Generate a new random interval
+    lastCycleEnd = currentMillis;                        // Reset time when test ended to now
+    Serial.println("Cycle completed. Waiting for " + String(timeBetweenTests) + " milliseconds.\n");
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@ const unsigned long solenoidHold = 100;         // pwm value for solenoid hold (
 const unsigned long solenoidPullDuration = 100; // duration solenoid operates at pull setting
 
 const unsigned long maxOnDuration = 2000; // Maximum duration solenoid can stay on in milliseconds
-const unsigned long maxInterval = 3000;   // Maximum interval between cycles in milliseconds
+const unsigned long maxInterval = 2500;   // Maximum interval between cycles in milliseconds
 const unsigned long minInterval = 500;    // Minimum interval between cycles in milliseconds
 
 unsigned long timeBetweenTests = random(minInterval, maxInterval); // Generate a random interval
@@ -88,24 +88,24 @@ void setup()
 
 void loop()
 {
-  unsigned long currentMillis = millis();
-
-  if (currentMillis - lastCycleEnd >= timeBetweenTests)
+  if (millis() - lastCycleEnd >= timeBetweenTests)
   {
 
     unsigned long onDuration = random(maxOnDuration); // Generate a random on duration
 
     Serial.println("Solenoid ON (" + String(onDuration) + " milliseconds)");
+    // Solenoid on at pull strength for pull duration
     analogWrite(solenoidPin, solenoidPull);
     delay(solenoidPullDuration);
+    // Solenoid on at hold strength for hold duration
     analogWrite(solenoidPin, solenoidHold);
     delay(onDuration);
+    // Solenoid off
     analogWrite(solenoidPin, 0);
-
     Serial.println("Solenoid OFF");
 
     unsigned long startTime = millis();
-    Serial.println(String(endstopCounter));
+
     while (millis() - startTime < 500)
     { // 500 ms timeout for detecting endstop
       if (endstopCounter >= 2)
@@ -125,7 +125,7 @@ void loop()
 
     endstopCounter = 0;                                  // Reset the endstop counter
     timeBetweenTests = random(minInterval, maxInterval); // Generate a new random interval
-    lastCycleEnd = currentMillis;                        // Reset time when test ended to now
+    lastCycleEnd = millis();                             // Reset time when test ended to now
     Serial.println("Cycle completed. Waiting for " + String(timeBetweenTests) + " milliseconds.\n");
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,8 @@ unsigned long passCount = 0;    // The number of passed tests so far
 unsigned long failCount = 0;    // The number of failed tests so far
 boolean detectedSolenoidOn = 0;
 boolean detectedSolenoidOff = 0;
+String testStart = "================Test Start===================";
+String testEnd = "=================Test End====================";
 
 // Board Configuration
 const int solenoidPin = 27; // Pin connected to solenoid
@@ -57,6 +59,7 @@ void logResult(String result)
 
   // Output test summary to serial
   Serial.println(testSummary);
+  Serial.println(testEnd);
 
   // Log to SD card
   File dataFile = SD.open("/text.txt", FILE_APPEND);
@@ -107,7 +110,7 @@ void loop()
   {
 
     unsigned long onDuration = random(maxOnDuration); // Generate a random on duration
-
+    Serial.println(testStart);
     Serial.println("Solenoid ON (" + String(onDuration) + " milliseconds)");
     endstopCounter = 0; // Reset end stop counter
     // Solenoid on at pull strength for pull duration
@@ -169,6 +172,6 @@ void loop()
     // endstopCounter = 0;                                  // Reset the endstop counter
     timeBetweenTests = random(minInterval, maxInterval); // Generate a new random interval
     lastCycleEnd = millis();                             // Reset time when test ended to now
-    Serial.println("Test complete. Waiting for " + String(timeBetweenTests) + " milliseconds.\n");
+    Serial.println("\nTest complete. Waiting for " + String(timeBetweenTests) + " milliseconds.\n");
   }
 }


### PR DESCRIPTION
Clean up the clunky AI logResult string stuff and output a running summary of pass/fail count.

```
Solenoid ON (2301 milliseconds)
Detected solenoid activation
Solenoid OFF
Detected solenoid de-activation
Detected: Solenoid ON: 1 Solenoid OFF: 1
Test 39 PASS
Total passed (39), total failed (0)
Test complete. Waiting for 1275 milliseconds.
```

Note: The current PASS/FAIL status shows as red or green if your terminal supports colour:
![image](https://github.com/theworkisthework/solenoid_repeatability_tester/assets/1804621/f022e1f0-63d4-49be-b626-6aeb1e4ef34e)
